### PR TITLE
Fix ajax_logout to return error when not logged in

### DIFF
--- a/fancy-login-logout.php
+++ b/fancy-login-logout.php
@@ -36,6 +36,10 @@ class WPFancyLoginLogout {
      */
     public function ajax_logout() {
         check_ajax_referer( 'wpfll_logout_nonce', 'security' );
+        if ( ! is_user_logged_in() ) {
+            wp_send_json_error();
+        }
+
         wp_logout();
         wp_send_json_success();
     }


### PR DESCRIPTION
## Summary
- prevent wp_logout from being called when a visitor isn't logged in

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865714867f083268e4235ef9272acc9