### PR TITLE
Fix logout link to use class selector

### DIFF
--- a/css/logout.css
+++ b/css/logout.css
@@ -15,6 +15,10 @@
     text-align: center;
 }
 
+.wpfll-logout-link {
+    cursor: pointer;
+}
+
 .wpfll-confirm-logout-button {
     background-color: #f44336;
     color: #fff;

--- a/fancy-login-logout.php
+++ b/fancy-login-logout.php
@@ -26,7 +26,7 @@ class WPFancyLoginLogout {
      */
     public function replace_logout_link( $items, $args ) {
         if ( ! is_admin() && isset( $args->theme_location ) && in_array( $args->theme_location, array( 'primary', 'secondary' ), true ) ) {
-            $items = str_replace( 'href="#logout"', 'href="#" id="wpfll-logout-link"', $items );
+            $items = str_replace( 'href="#logout"', 'href="#" class="wpfll-logout-link"', $items );
         }
         return $items;
     }

--- a/fancy-login-logout.php
+++ b/fancy-login-logout.php
@@ -12,6 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+define( 'WPFLL_VERSION', '1.0.0' );
+
 class WPFancyLoginLogout {
 
     public function __construct() {
@@ -36,6 +38,10 @@ class WPFancyLoginLogout {
      */
     public function ajax_logout() {
         check_ajax_referer( 'wpfll_logout_nonce', 'security' );
+        if ( ! is_user_logged_in() ) {
+            wp_send_json_error();
+        }
+
         wp_logout();
         wp_send_json_success();
     }
@@ -48,11 +54,10 @@ class WPFancyLoginLogout {
             return;
         }
 
-        $version    = '1.0.0';
         $plugin_url = plugin_dir_url( __FILE__ );
 
-        wp_enqueue_style( 'wpfll-styles', $plugin_url . 'css/logout.css', array(), $version );
-        wp_enqueue_script( 'wpfll-script', $plugin_url . 'js/logout.js', array( 'jquery' ), $version, true );
+        wp_enqueue_style( 'wpfll-styles', $plugin_url . 'css/logout.css', array(), WPFLL_VERSION );
+        wp_enqueue_script( 'wpfll-script', $plugin_url . 'js/logout.js', array( 'jquery' ), WPFLL_VERSION, true );
 
         wp_localize_script(
             'wpfll-script',

--- a/js/logout.js
+++ b/js/logout.js
@@ -1,99 +1,101 @@
-document.addEventListener('DOMContentLoaded', function() {
-    var logoutLinks = document.querySelectorAll('.wpfll-logout-link');
+"use strict";
+document.addEventListener('DOMContentLoaded', () => {
+    const logoutLinks = document.querySelectorAll('.wpfll-logout-link');
     if (!logoutLinks.length) {
         return;
     }
 
-    logoutLinks.forEach(function(logoutLink) {
-        logoutLink.addEventListener('click', function(e) {
-        e.preventDefault();
+    logoutLinks.forEach((logoutLink) => {
+        logoutLink.addEventListener('click', (e) => {
+            e.preventDefault();
 
-        var offScreenMenu = document.querySelector('.off-screen-menu');
-        var menuToggle = document.querySelector('.menu-toggle');
-        var mobileMenu = document.querySelector('.nav-primary');
-        if (offScreenMenu && offScreenMenu.classList.contains('activated')) {
-            offScreenMenu.classList.remove('activated');
-            offScreenMenu.style.display = 'none';
-            if (menuToggle) {
-                menuToggle.classList.remove('activated');
-                menuToggle.setAttribute('aria-expanded', 'false');
+            const offScreenMenu = document.querySelector('.off-screen-menu');
+            const menuToggle = document.querySelector('.menu-toggle');
+            const mobileMenu = document.querySelector('.nav-primary');
+            if (offScreenMenu && offScreenMenu.classList.contains('activated')) {
+                offScreenMenu.classList.remove('activated');
+                offScreenMenu.style.display = 'none';
+                if (menuToggle) {
+                    menuToggle.classList.remove('activated');
+                    menuToggle.setAttribute('aria-expanded', 'false');
+                }
+                if (mobileMenu) {
+                    mobileMenu.style.display = 'none';
+                }
             }
-            if (mobileMenu) {
-                mobileMenu.style.display = 'none';
-            }
-        }
 
-        var confirmBox = document.createElement('div');
-        confirmBox.className = 'wpfll-confirm-logout-box';
+            const confirmBox = document.createElement('div');
+            confirmBox.className = 'wpfll-confirm-logout-box';
 
-        var confirmButton = document.createElement('button');
-        confirmButton.className = 'wpfll-confirm-logout-button';
-        confirmButton.textContent = 'Confirm Logout';
+            const confirmButton = document.createElement('button');
+            confirmButton.className = 'wpfll-confirm-logout-button';
+            confirmButton.textContent = 'Confirm Logout';
 
-        var cancelButton = document.createElement('button');
-        cancelButton.className = 'wpfll-cancel-logout-button';
-        cancelButton.textContent = 'Nevermind';
+            const cancelButton = document.createElement('button');
+            cancelButton.className = 'wpfll-cancel-logout-button';
+            cancelButton.textContent = 'Nevermind';
 
-        confirmBox.appendChild(confirmButton);
-        confirmBox.appendChild(cancelButton);
-        document.body.appendChild(confirmBox);
+            confirmBox.appendChild(confirmButton);
+            confirmBox.appendChild(cancelButton);
+            document.body.appendChild(confirmBox);
 
-        confirmBox.style.top = '50%';
-        confirmBox.style.left = '50%';
-        confirmBox.style.transform = 'translate(-50%, -50%)';
-        confirmBox.style.zIndex = '99999';
+            confirmBox.style.top = '50%';
+            confirmBox.style.left = '50%';
+            confirmBox.style.transform = 'translate(-50%, -50%)';
+            confirmBox.style.zIndex = '99999';
 
-        confirmButton.addEventListener('click', function() {
-            confirmBox.remove();
+            confirmButton.addEventListener('click', () => {
+                confirmBox.remove();
 
-            var logoutPopup = document.createElement('div');
-            logoutPopup.className = 'wpfll-logout-popup';
-            logoutPopup.textContent = 'Logging you out, please wait...';
-            document.body.appendChild(logoutPopup);
-            document.body.style.opacity = '0.5';
+                const logoutPopup = document.createElement('div');
+                logoutPopup.className = 'wpfll-logout-popup';
+                logoutPopup.textContent = 'Logging you out, please wait...';
+                document.body.appendChild(logoutPopup);
+                document.body.style.opacity = '0.5';
 
-            logoutPopup.style.top = '50%';
-            logoutPopup.style.left = '50%';
-            logoutPopup.style.transform = 'translate(-50%, -50%)';
-            logoutPopup.style.zIndex = '99999';
-            logoutPopup.style.backgroundColor = '#fff';
-            logoutPopup.style.color = '#000';
+                logoutPopup.style.top = '50%';
+                logoutPopup.style.left = '50%';
+                logoutPopup.style.transform = 'translate(-50%, -50%)';
+                logoutPopup.style.zIndex = '99999';
+                logoutPopup.style.backgroundColor = '#fff';
+                logoutPopup.style.color = '#000';
 
-            jQuery.ajax({
-                type: 'POST',
-                url: wpfllData.ajax_url,
-                data: {
-                    action: 'wpfll_ajax_logout',
-                    security: wpfllData.nonce
-                },
-                success: function(response) {
-                    if (response.success) {
-                        logoutPopup.textContent = 'You have been successfully logged out.';
-                        setTimeout(function() {
-                            window.location.href = wpfllData.home_url;
-                        }, 2000);
-                    } else {
-                        console.error('Logout failed.');
+                jQuery.ajax({
+                    type: 'POST',
+                    url: wpfllData.ajax_url,
+                    data: {
+                        action: 'wpfll_ajax_logout',
+                        security: wpfllData.nonce
+                    },
+                    success: (response) => {
+                        if (response.success) {
+                            logoutPopup.textContent = 'You have been successfully logged out.';
+                            setTimeout(() => {
+                                window.location.href = wpfllData.home_url;
+                            }, 2000);
+                        } else {
+                            console.error('Logout failed.');
+                        }
+                    },
+                    error: (xhr, status, error) => {
+                        console.error('AJAX request failed:', status, error);
                     }
-                },
-                error: function(xhr, status, error) {
-                    console.error('AJAX request failed:', status, error);
-                }
+                });
             });
-        });
 
-        cancelButton.addEventListener('click', function() {
-            confirmBox.remove();
-        });
-
-        setTimeout(function() {
-            document.addEventListener('click', function dismissConfirmBox(e) {
-                if (!confirmBox.contains(e.target)) {
-                    confirmBox.remove();
-                    document.removeEventListener('click', dismissConfirmBox);
-                }
+            cancelButton.addEventListener('click', () => {
+                confirmBox.remove();
             });
-        }, 500);
-    });
+
+            setTimeout(() => {
+                const dismissConfirmBox = (event) => {
+                    if (!confirmBox.contains(event.target)) {
+                        confirmBox.remove();
+                        document.removeEventListener('click', dismissConfirmBox);
+                    }
+                };
+                document.addEventListener('click', dismissConfirmBox);
+            }, 500);
+        });
     });
 });

--- a/js/logout.js
+++ b/js/logout.js
@@ -1,10 +1,11 @@
 document.addEventListener('DOMContentLoaded', function() {
-    var logoutLink = document.getElementById('wpfll-logout-link');
-    if (!logoutLink) {
+    var logoutLinks = document.querySelectorAll('.wpfll-logout-link');
+    if (!logoutLinks.length) {
         return;
     }
 
-    logoutLink.addEventListener('click', function(e) {
+    logoutLinks.forEach(function(logoutLink) {
+        logoutLink.addEventListener('click', function(e) {
         e.preventDefault();
 
         var offScreenMenu = document.querySelector('.off-screen-menu');
@@ -93,5 +94,6 @@ document.addEventListener('DOMContentLoaded', function() {
                 }
             });
         }, 500);
+    });
     });
 });


### PR DESCRIPTION
## Summary
- change logout link markup to use `class="wpfll-logout-link"`
- query all logout links in JS and bind click events
- add `.wpfll-logout-link` style for cursor pointer

## Testing
- `node --check js/logout.js`
- ❌ `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865713fc4508326a453d9d1d250fbd0