### PR TITLE
Add translation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,8 @@ This plugin provides a simple JavaScript powered logout confirmation popup. The 
 - Confirmation dialog before logging out.
 - Popup message while the logout request is processed.
 
+## Translating
+
+The plugin text domain is `wp-fancy-login-logout`. Translation files can be placed in a `languages` folder inside the plugin directory. Use standard WordPress tools such as [Poedit](https://poedit.net/) or WP-CLI to generate translation files.
+
 This plugin is released under the GPLv3 license.

--- a/fancy-login-logout.php
+++ b/fancy-login-logout.php
@@ -6,6 +6,7 @@
  * Author: WP Fancy Plugin Contributors
  * License: GPLv3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
+ * Text Domain: wp-fancy-login-logout
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -19,6 +20,14 @@ class WPFancyLoginLogout {
         add_action( 'wp_ajax_nopriv_wpfll_ajax_logout', array( $this, 'ajax_logout' ) );
         add_action( 'wp_ajax_wpfll_ajax_logout', array( $this, 'ajax_logout' ) );
         add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+        add_action( 'init', array( $this, 'load_textdomain' ) );
+    }
+
+    /**
+     * Load plugin textdomain for translations.
+     */
+    public function load_textdomain() {
+        load_plugin_textdomain( 'wp-fancy-login-logout', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
     }
 
     /**
@@ -61,6 +70,13 @@ class WPFancyLoginLogout {
                 'ajax_url' => admin_url( 'admin-ajax.php' ),
                 'nonce'    => wp_create_nonce( 'wpfll_logout_nonce' ),
                 'home_url' => home_url(),
+                'i18n'     => array(
+                    'confirmLogout' => esc_html__( 'Confirm Logout', 'wp-fancy-login-logout' ),
+                    'nevermind'     => esc_html__( 'Nevermind', 'wp-fancy-login-logout' ),
+                    'loggingOut'    => esc_html__( 'Logging you out, please wait...', 'wp-fancy-login-logout' ),
+                    'logoutSuccess' => esc_html__( 'You have been successfully logged out.', 'wp-fancy-login-logout' ),
+                    'logoutFailed'  => esc_html__( 'Logout failed.', 'wp-fancy-login-logout' ),
+                ),
             )
         );
     }

--- a/js/logout.js
+++ b/js/logout.js
@@ -27,11 +27,11 @@ document.addEventListener('DOMContentLoaded', function() {
 
         var confirmButton = document.createElement('button');
         confirmButton.className = 'wpfll-confirm-logout-button';
-        confirmButton.textContent = 'Confirm Logout';
+        confirmButton.textContent = wpfllData.i18n.confirmLogout;
 
         var cancelButton = document.createElement('button');
         cancelButton.className = 'wpfll-cancel-logout-button';
-        cancelButton.textContent = 'Nevermind';
+        cancelButton.textContent = wpfllData.i18n.nevermind;
 
         confirmBox.appendChild(confirmButton);
         confirmBox.appendChild(cancelButton);
@@ -47,7 +47,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
             var logoutPopup = document.createElement('div');
             logoutPopup.className = 'wpfll-logout-popup';
-            logoutPopup.textContent = 'Logging you out, please wait...';
+            logoutPopup.textContent = wpfllData.i18n.loggingOut;
             document.body.appendChild(logoutPopup);
             document.body.style.opacity = '0.5';
 
@@ -67,12 +67,12 @@ document.addEventListener('DOMContentLoaded', function() {
                 },
                 success: function(response) {
                     if (response.success) {
-                        logoutPopup.textContent = 'You have been successfully logged out.';
+                        logoutPopup.textContent = wpfllData.i18n.logoutSuccess;
                         setTimeout(function() {
                             window.location.href = wpfllData.home_url;
                         }, 2000);
                     } else {
-                        console.error('Logout failed.');
+                        console.error(wpfllData.i18n.logoutFailed);
                     }
                 },
                 error: function(xhr, status, error) {

--- a/languages/index.php
+++ b/languages/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden.


### PR DESCRIPTION
## Summary
- declare plugin text domain
- load plugin translations on `init`
- provide localized strings to JavaScript
- hook up JS to use localized strings
- document translation steps

## Testing
- `php -l fancy-login-logout.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865715bbc608326ba42cbe1e54ad291