### PR TITLE
Add i18n support for logout messages

### DIFF
--- a/fancy-login-logout.php
+++ b/fancy-login-logout.php
@@ -57,7 +57,11 @@ class WPFancyLoginLogout {
         $plugin_url = plugin_dir_url( __FILE__ );
 
         wp_enqueue_style( 'wpfll-styles', $plugin_url . 'css/logout.css', array(), WPFLL_VERSION );
-        wp_enqueue_script( 'wpfll-script', $plugin_url . 'js/logout.js', array( 'jquery' ), WPFLL_VERSION, true );
+        wp_enqueue_script( 'wpfll-script', $plugin_url . 'js/logout.js', array( 'jquery', 'wp-i18n' ), WPFLL_VERSION, true );
+
+        if ( function_exists( 'wp_set_script_translations' ) ) {
+            wp_set_script_translations( 'wpfll-script', 'wp-fancy-login-logout', plugin_dir_path( __FILE__ ) . 'languages' );
+        }
 
         wp_localize_script(
             'wpfll-script',

--- a/js/logout.js
+++ b/js/logout.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
     'use strict';
+    const { __ } = wp.i18n || { __: ( s ) => s };
     const logoutLink = document.getElementById('wpfll-logout-link');
     if (!logoutLink) {
         return;
@@ -28,11 +29,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const confirmButton = document.createElement('button');
         confirmButton.className = 'wpfll-confirm-logout-button';
-        confirmButton.textContent = 'Confirm Logout';
+        confirmButton.textContent = __( 'Confirm Logout', 'wp-fancy-login-logout' );
 
         const cancelButton = document.createElement('button');
         cancelButton.className = 'wpfll-cancel-logout-button';
-        cancelButton.textContent = 'Nevermind';
+        cancelButton.textContent = __( 'Nevermind', 'wp-fancy-login-logout' );
 
         confirmBox.appendChild(confirmButton);
         confirmBox.appendChild(cancelButton);
@@ -48,7 +49,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
             const logoutPopup = document.createElement('div');
             logoutPopup.className = 'wpfll-logout-popup';
-            logoutPopup.textContent = 'Logging you out, please wait...';
+            logoutPopup.textContent = __( 'Logging you out, please wait...', 'wp-fancy-login-logout' );
             document.body.appendChild(logoutPopup);
             document.body.style.opacity = '0.5';
 
@@ -68,16 +69,16 @@ document.addEventListener('DOMContentLoaded', () => {
                 },
                 success: (response) => {
                     if (response.success) {
-                        logoutPopup.textContent = 'You have been successfully logged out.';
+                        logoutPopup.textContent = __( 'You have been successfully logged out.', 'wp-fancy-login-logout' );
                         setTimeout(() => {
                             window.location.href = wpfllData.home_url;
                         }, 2000);
                     } else {
-                        console.error('Logout failed.');
+                        console.error( __( 'Logout failed.', 'wp-fancy-login-logout' ) );
                     }
                 },
                 error: (xhr, status, error) => {
-                    console.error('AJAX request failed:', status, error);
+                    console.error( __( 'AJAX request failed:', 'wp-fancy-login-logout' ), status, error );
                 }
             });
         });


### PR DESCRIPTION
## Summary
- enqueue translations when loading the logout script
- use `wp.i18n.__` in logout.js
- add empty POT file for translations

## Testing
- `node --check js/logout.js`


------
https://chatgpt.com/codex/tasks/task_e_686575e5ed4c8326bb8854a743c4ee62