### PR TITLE
Add AJAX error message handling

### DIFF
--- a/css/logout.css
+++ b/css/logout.css
@@ -44,3 +44,14 @@
 .wpfll-cancel-logout-button:hover {
     background-color: #f0f0f0;
 }
+
+.wpfll-error-message {
+    position: fixed;
+    top: 10px;
+    right: 10px;
+    background-color: #f44336;
+    color: #fff;
+    padding: 10px 20px;
+    border-radius: 5px;
+    z-index: 99999;
+}

--- a/fancy-login-logout.php
+++ b/fancy-login-logout.php
@@ -66,6 +66,9 @@ class WPFancyLoginLogout {
                 'ajax_url' => admin_url( 'admin-ajax.php' ),
                 'nonce'    => wp_create_nonce( 'wpfll_logout_nonce' ),
                 'home_url' => home_url(),
+                'i18n'     => array(
+                    'ajaxError' => esc_html__( 'AJAX request failed.', 'wp-fancy-login-logout' ),
+                ),
             )
         );
     }

--- a/js/logout.js
+++ b/js/logout.js
@@ -77,7 +77,14 @@ document.addEventListener('DOMContentLoaded', () => {
                     }
                 },
                 error: (xhr, status, error) => {
-                    console.error('AJAX request failed:', status, error);
+                    console.error(wpfllData.i18n.ajaxError, status, error);
+                    const errorDiv = document.createElement('div');
+                    errorDiv.className = 'wpfll-error-message';
+                    errorDiv.textContent = wpfllData.i18n.ajaxError;
+                    document.body.appendChild(errorDiv);
+                    setTimeout(() => {
+                        errorDiv.remove();
+                    }, 3000);
                 }
             });
         });


### PR DESCRIPTION
## Summary
- provide a localized error string for AJAX failures
- display AJAX errors in the UI and console
- style the logout error message

## Testing
- `php -l fancy-login-logout.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686575e69d908326bb57bda3015c61e8