### PR TITLE
Load translations early

### DIFF
--- a/fancy-login-logout.php
+++ b/fancy-login-logout.php
@@ -17,10 +17,18 @@ define( 'WPFLL_VERSION', '1.0.0' );
 class WPFancyLoginLogout {
 
     public function __construct() {
+        add_action( 'init', array( $this, 'load_textdomain' ), 0 );
         add_filter( 'nav_menu_link_attributes', array( $this, 'mark_logout_link' ), 10, 3 );
         add_action( 'wp_ajax_nopriv_wpfll_ajax_logout', array( $this, 'ajax_logout' ) );
         add_action( 'wp_ajax_wpfll_ajax_logout', array( $this, 'ajax_logout' ) );
         add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+    }
+
+    /**
+     * Load plugin text domain for translations.
+     */
+    public function load_textdomain() {
+        load_plugin_textdomain( 'wp-fancy-login-logout', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
     }
 
     /**


### PR DESCRIPTION
## Summary
- load translation files on `init`

## Testing
- `php -l fancy-login-logout.php`


------
https://chatgpt.com/codex/tasks/task_e_6865a10be6908326a273d61663d9a112