### PR TITLE
Add generated translation template

### DIFF
--- a/languages/wp-fancy-login-logout.pot
+++ b/languages/wp-fancy-login-logout.pot
@@ -1,0 +1,30 @@
+# Copyright (C) 2025 WP Fancy Plugin Contributors
+# This file is distributed under the GPLv3.
+msgid ""
+msgstr ""
+"Project-Id-Version: WP Fancy Login Logout 1.0.0\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/WP-Fancy-Login-Logout\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-07-02T21:19:07+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: WP-Fancy-Login-Logout\n"
+
+#. Plugin Name of the plugin
+#: fancy-login-logout.php
+msgid "WP Fancy Login Logout"
+msgstr ""
+
+#. Description of the plugin
+#: fancy-login-logout.php
+msgid "Adds a logout confirmation popup and handles the logout process via AJAX."
+msgstr ""
+
+#. Author of the plugin
+#: fancy-login-logout.php
+msgid "WP Fancy Plugin Contributors"
+msgstr ""


### PR DESCRIPTION
## Summary
- generate `languages/wp-fancy-login-logout.pot` with WP‑CLI so translators have strings to work with

## Testing
- `wp --allow-root i18n make-pot . languages/wp-fancy-login-logout.pot --skip-js`


------
https://chatgpt.com/codex/tasks/task_e_6865a1c8e32c8326accc551c49f31b4e