### PR TITLE
Fix overlay opacity reset on logout failure

### DIFF
--- a/js/logout.js
+++ b/js/logout.js
@@ -72,13 +72,19 @@ document.addEventListener('DOMContentLoaded', () => {
                     if (response.success) {
                         logoutPopup.textContent = __( 'You have been successfully logged out.', 'wp-fancy-login-logout' );
                         setTimeout(() => {
+                            logoutPopup.remove();
+                            document.body.style.opacity = '1';
                             window.location.href = wpfllData.home_url;
                         }, 2000);
                     } else {
+                        logoutPopup.remove();
+                        document.body.style.opacity = '1';
                         console.error( __( 'Logout failed.', 'wp-fancy-login-logout' ) );
                     }
                 },
                 error: (xhr, status, error) => {
+                    logoutPopup.remove();
+                    document.body.style.opacity = '1';
                     console.error(wpfllData.i18n.ajaxError, status, error);
                     const errorDiv = document.createElement('div');
                     errorDiv.className = 'wpfll-error-message';


### PR DESCRIPTION
## Summary
- reset page opacity after removing the logout popup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865a1ce99f08326825679cc844b0451